### PR TITLE
Add pseudo-theme configs for testing

### DIFF
--- a/Config.gd
+++ b/Config.gd
@@ -114,10 +114,12 @@ func fetch_game_data(path: String, game: RetroHubGameData) -> bool:
 	return true
 
 func get_theme_config(key, default_value):
-	return default_value
+	if not _theme_config.has(key):
+		_theme_config[key] = default_value
+	return _theme_config[key]
 
 func set_theme_config(key, value):
-	pass
+	_theme_config[key] = value
 
 func get_config_dir() -> String:
 	match FileUtils.get_os_id():


### PR DESCRIPTION
Simulates behavior from theme settings. They are basically reset on each run, but it's actually a good practice to ensure settings are reflected in real-time.